### PR TITLE
Modbus command supports GPIO RW

### DIFF
--- a/meta-facebook/aalc_predev/src/platform/plat_gpio.c
+++ b/meta-facebook/aalc_predev/src/platform/plat_gpio.c
@@ -394,3 +394,8 @@ bool pal_load_gpio_config(void)
 	memcpy(&gpio_cfg[0], &plat_gpio_cfg[0], sizeof(plat_gpio_cfg));
 	return 1;
 };
+
+uint16_t plat_gpio_cfg_size(void)
+{
+	return ARRAY_SIZE(plat_gpio_cfg);
+};

--- a/meta-facebook/aalc_predev/src/platform/plat_gpio.h
+++ b/meta-facebook/aalc_predev/src/platform/plat_gpio.h
@@ -20,6 +20,7 @@
 #include "hal_gpio.h"
 
 void gpio_int_default();
+uint16_t plat_gpio_cfg_size(void);
 
 // clang-format off
 


### PR DESCRIPTION
Modbus command supports GPIO RW:
Type: FC01 05 15
CPIO num is the Data Address of the coil. The range is 0~(plat_gpio_cfg size -1) 
